### PR TITLE
Point to new discussion-questions repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,14 +169,14 @@ layout: default
 
      <div class="row">
       <div class="col-sm-2 d-none d-md-block">
-         <a target="_blank" href="https://github.com/Qala-Dev/mastering-bitcoin-discussion-questions">
+         <a target="_blank" href="https://github.com/Qala-Dev/discussion-questions/tree/main/mastering-bitcoin">
             <span class="fa-stack fa-4x">
              <i class="fa fa-book" style="color:black"></i>
             </span>
          </a>
       </div>
        <div class="col-sm-10">
-         <a target="_blank" href="https://github.com/Qala-Dev/mastering-bitcoin-discussion-questions">
+         <a target="_blank" href="https://github.com/Qala-Dev/discussion-questions/tree/main/mastering-bitcoin">
            <h4>Discussion Questions for Mastering Bitcoin</h4>
          </a>
          <p class="text-muted">Mastering Bitcoin is a book for developers, although the first two chapters cover bitcoin at a level that is also approachable to non-programmers. Anyone with a basic understanding of technology can read the first two chapters to get a great understanding of bitcoin.</p>
@@ -186,7 +186,7 @@ layout: default
      <div class="row">
       <div class="col-sm-2 d-none d-md-block">
          <a target="_blank" href="https://chaincode.gitbook.io/seminars/">
-            <span class="fa-stack fa-4x"> 
+            <span class="fa-stack fa-4x">
                <i class="fas fa-laptop-code" style="color:black"></i>
             </span>
          </a>


### PR DESCRIPTION
I've created the more generic [discussion-questions](https://github.com/Qala-Dev/discussion-questions) with subfolders per resource, and copied ([67060fb](https://github.com/Qala-Dev/discussion-questions/commit/40cfdb1b7b5fe62279fb81af33938a6ae673d3d4)) the Mastering Bitcoin questions in there. 

I'd suggest to update all references to this new repo and then delete `mastering-bitcoin-discussion-questions`. I don't think we have any dependencies beyond what's changed in this PR?

Note: I've added MIT license to `discussion-questions`, whereas `mastering-bitcoin-discussion-questions` didn't have any. I assumed that's what's preferred, given the license here in `qala-website`.